### PR TITLE
[MAN-1574] Update upstream Docker image for new Conan version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wsbu/toolchain-native:v0.3.4
+FROM wsbu/toolchain-native:v0.3.5
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
There's a lot to update whenever the Conan version changes. This is the Docker image being used to hold the TeamCity agents.