### PR TITLE
[MAN-1602] Add 'expect'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM wsbu/toolchain-native:v0.3.5
 RUN apt-get update && \
     apt-get install -y \
         docker.io \
+        expect \
         unzip \
         openjdk-8-jre-headless \
         git-core \


### PR DESCRIPTION
Lance would like to run the `ssh-copy-id-s5t.exp` script as part of the Manticore I/O regression suite. He'll need `expect` to do that.