### PR TITLE
Add teamcity-message pip package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN sudo -H pip3 install \
     boto3 \
     xmltodict \
     paramiko \
-    conan_package_tools
+    conan_package_tools \
+    teamcity-messages
 
 RUN sudo wget --quiet -O /usr/local/bin/docker-compose \
         https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m)  && \


### PR DESCRIPTION
Apparently I never added teamcity-messages as a pip package.